### PR TITLE
Prevent navigation from assertion crashing...

### DIFF
--- a/lib/ios/RNNEventEmitter.m
+++ b/lib/ios/RNNEventEmitter.m
@@ -52,6 +52,9 @@ static NSString* const onNavigationButtonPressed	= @"RNN.navigationButtonPressed
 # pragma mark private
 
 -(void)send:(NSString *)eventName body:(id)body {
+    if ([eventName isEqualToString:containerDidDisappear] && self.bridge == nil) {
+        return;
+    }
 	[self sendEventWithName:eventName body:body];
 }
 


### PR DESCRIPTION
... when restarting the app during the initialization phase.

Code push reloading the application while its foregrounding is causing an assertion. It looks like the old controller sending off a `RNN.containerDidDisappear` event is causing this.

below is the stack trace:

```
2018-02-06 11:54:31.538092-0800 FacemaskReference[35876:495578] *** Terminating app due to uncaught exception 'NSInternalInconsistencyException', reason: 'Error when sending event: RNN.containerDidDisappear with body: Container4. Bridge is not set. This is probably because you've explicitly synthesized the bridge in RNNEventEmitter, even though it's inherited from RCTEventEmitter.'
*** First throw call stack:
(
	0   CoreFoundation                      0x0000000106cbb12b __exceptionPreprocess + 171
	1   libobjc.A.dylib                     0x000000010504cf41 objc_exception_throw + 48
	2   CoreFoundation                      0x0000000106cc02f2 +[NSException raise:format:arguments:] + 98
	3   Foundation                          0x0000000101cae3db -[NSAssertionHandler handleFailureInFunction:file:lineNumber:description:] + 165
	4   FacemaskReference                   0x0000000100804b17 -[RCTEventEmitter sendEventWithName:body:] + 567
	5   FacemaskReference                   0x00000001009b8f1d -[RNNEventEmitter send:body:] + 109
	6   FacemaskReference                   0x00000001009b8c1d -[RNNEventEmitter sendContainerDidDisappear:] + 109
	7   FacemaskReference                   0x00000001009c3bcb -[RNNRootViewController viewDidDisappear:] + 171
	8   UIKit                               0x0000000102f280e3 -[UIViewController _setViewAppearState:isAnimating:] + 335
	9   UIKit                               0x0000000102f28c02 -[UIViewController __viewDidDisappear:] + 132
	10  UIKit                               0x0000000102f5ffd8 -[UINavigationController viewDidDisappear:] + 255
	11  UIKit                               0x0000000102f280e3 -[UIViewController _setViewAppearState:isAnimating:] + 335
	12  UIKit                               0x0000000102f287b1 __52-[UIViewController _setViewAppearState:isAnimating:]_block_invoke + 265
	13  CoreFoundation                      0x0000000106cfb57a -[__NSSingleObjectArrayI enumerateObjectsWithOptions:usingBlock:] + 58
	14  UIKit                               0x0000000102f2845c -[UIViewController _setViewAppearState:isAnimating:] + 1224
	15  UIKit                               0x0000000102f28c02 -[UIViewController __viewDidDisappear:] + 132
	16  UIKit                               0x0000000102f28cf6 -[UIViewController _endAppearanceTransition:] + 197
	17  FacemaskReference                   0x000000010099fb88 -[MMDrawerController viewDidDisappear:] + 136
	18  UIKit                               0x0000000102f280e3 -[UIViewController _setViewAppearState:isAnimating:] + 335
	19  UIKit                               0x0000000102f287b1 __52-[UIViewController _setViewAppearState:isAnimating:]_block_invoke + 265
	20  CoreFoundation                      0x0000000106cfb57a -[__NSSingleObjectArrayI enumerateObjectsWithOptions:usingBlock:] + 58
	21  UIKit                               0x0000000102f2845c -[UIViewController _setViewAppearState:isAnimating:] + 1224
	22  UIKit                               0x0000000102f28c02 -[UIViewController __viewDidDisappear:] + 132
	23  UIKit                               0x0000000102f2b1d8 __64-[UIViewController viewDidMoveToWindow:shouldAppearOrDisappear:]_block_invoke.1397 + 42
	24  UIKit                               0x0000000102f293ed -[UIViewController _executeAfterAppearanceBlock] + 86
	25  UIKit                               0x0000000102d85e95 _runAfterCACommitDeferredBlocks + 634
	26  UIKit                               0x0000000102d74bb1 _cleanUpAfterCAFlushAndRunDeferredBlocks + 280
	27  UIKit                               0x0000000102da40e0 _afterCACommitHandler + 137
	28  CoreFoundation                      0x0000000106c5dc07 __CFRUNLOOP_IS_CALLING_OUT_TO_AN_OBSERVER_CALLBACK_FUNCTION__ + 23
	29  CoreFoundation                      0x0000000106c5db5e __CFRunLoopDoObservers + 430
	30  CoreFoundation                      0x0000000106c42124 __CFRunLoopRun + 1572
	31  CoreFoundation                      0x0000000106c41889 CFRunLoopRunSpecific + 409
	32  GraphicsServices                    0x000000010ca579c6 GSEventRunModal + 62
	33  UIKit                               0x0000000102d7a5d6 UIApplicationMain + 159
	34  FacemaskReference                   0x000000010071f8d7 main + 55
	35  libdyld.dylib                       0x000000010b088d81 start + 1
	36  ???                                 0x0000000000000001 0x0 + 1
)
libc++abi.dylib: terminating with uncaught exception of type NSException
```
