### PR TITLE
Allow customNavigationTitleView and customNavigationBarView to be tra…

### DIFF
--- a/lib/ios/RNNRootViewController.m
+++ b/lib/ios/RNNRootViewController.m
@@ -77,6 +77,8 @@
 		UIView *reactView = [_creator createRootView:self.options.topBar.customTitleViewName rootViewId:self.options.topBar.customTitleViewName];
 
 		RNNCustomTitleView *titleView = [[RNNCustomTitleView alloc] initWithFrame:self.navigationController.navigationBar.bounds subView:reactView alignment:nil];
+		reactView.backgroundColor = UIColor.clearColor;
+		titleView.backgroundColor = UIColor.clearColor;
 		self.navigationItem.titleView = titleView;
 	}
 }
@@ -86,6 +88,8 @@
 		UIView *reactView = [_creator createRootView:self.options.topBar.customViewName rootViewId:@"navBar"];
 
 		RNNCustomTitleView *titleView = [[RNNCustomTitleView alloc] initWithFrame:self.navigationController.navigationBar.bounds subView:reactView alignment:nil];
+		reactView.backgroundColor = UIColor.clearColor;
+		titleView.backgroundColor = UIColor.clearColor;
 		[self.navigationController.navigationBar addSubview:titleView];
 	}
 }

--- a/lib/ios/RNNRootViewController.m
+++ b/lib/ios/RNNRootViewController.m
@@ -77,8 +77,6 @@
 		UIView *reactView = [_creator createRootView:self.options.topBar.customTitleViewName rootViewId:self.options.topBar.customTitleViewName];
 
 		RNNCustomTitleView *titleView = [[RNNCustomTitleView alloc] initWithFrame:self.navigationController.navigationBar.bounds subView:reactView alignment:nil];
-        reactView.backgroundColor = UIColor.clearColor;
-        titleView.backgroundColor = UIColor.clearColor;
 		self.navigationItem.titleView = titleView;
 	}
 }
@@ -88,8 +86,6 @@
 		UIView *reactView = [_creator createRootView:self.options.topBar.customViewName rootViewId:@"navBar"];
 
 		RNNCustomTitleView *titleView = [[RNNCustomTitleView alloc] initWithFrame:self.navigationController.navigationBar.bounds subView:reactView alignment:nil];
-        reactView.backgroundColor = UIColor.clearColor;
-        titleView.backgroundColor = UIColor.clearColor;
 		[self.navigationController.navigationBar addSubview:titleView];
 	}
 }

--- a/lib/ios/RNNRootViewController.m
+++ b/lib/ios/RNNRootViewController.m
@@ -26,13 +26,13 @@
 	self.animator = [[RNNAnimator alloc] initWithTransitionOptions:self.options.customTransition];
 	self.creator = creator;
 	self.isNativeComponent = isNativeComponent;
-	
+
 	if (self.isNativeComponent) {
 		[self addExternalVC:name];
 	} else {
 		self.view = [creator createRootView:self.componentName rootViewId:self.componentId];
 	}
-	
+
 	[[NSNotificationCenter defaultCenter] addObserver:self
 											 selector:@selector(onJsReload)
 												 name:RCTJavaScriptWillStartLoadingNotification
@@ -42,7 +42,7 @@
 
 	return self;
 }
-	
+
 -(void)viewWillAppear:(BOOL)animated{
 	[super viewWillAppear:animated];
 	[self.options applyOn:self];
@@ -75,7 +75,7 @@
 - (void)setCustomNavigationTitleView {
 	if (self.options.topBar.customTitleViewName) {
 		UIView *reactView = [_creator createRootView:self.options.topBar.customTitleViewName rootViewId:self.options.topBar.customTitleViewName];
-		
+
 		RNNCustomTitleView *titleView = [[RNNCustomTitleView alloc] initWithFrame:self.navigationController.navigationBar.bounds subView:reactView alignment:nil];
         reactView.backgroundColor = UIColor.clearColor;
         titleView.backgroundColor = UIColor.clearColor;
@@ -86,7 +86,7 @@
 - (void)setCustomNavigationBarView {
 	if (self.options.topBar.customViewName) {
 		UIView *reactView = [_creator createRootView:self.options.topBar.customViewName rootViewId:@"navBar"];
-		
+
 		RNNCustomTitleView *titleView = [[RNNCustomTitleView alloc] initWithFrame:self.navigationController.navigationBar.bounds subView:reactView alignment:nil];
         reactView.backgroundColor = UIColor.clearColor;
         titleView.backgroundColor = UIColor.clearColor;

--- a/lib/ios/RNNRootViewController.m
+++ b/lib/ios/RNNRootViewController.m
@@ -77,6 +77,8 @@
 		UIView *reactView = [_creator createRootView:self.options.topBar.customTitleViewName rootViewId:self.options.topBar.customTitleViewName];
 		
 		RNNCustomTitleView *titleView = [[RNNCustomTitleView alloc] initWithFrame:self.navigationController.navigationBar.bounds subView:reactView alignment:nil];
+        reactView.backgroundColor = UIColor.clearColor;
+        titleView.backgroundColor = UIColor.clearColor;
 		self.navigationItem.titleView = titleView;
 	}
 }
@@ -86,6 +88,8 @@
 		UIView *reactView = [_creator createRootView:self.options.topBar.customViewName rootViewId:@"navBar"];
 		
 		RNNCustomTitleView *titleView = [[RNNCustomTitleView alloc] initWithFrame:self.navigationController.navigationBar.bounds subView:reactView alignment:nil];
+        reactView.backgroundColor = UIColor.clearColor;
+        titleView.backgroundColor = UIColor.clearColor;
 		[self.navigationController.navigationBar addSubview:titleView];
 	}
 }


### PR DESCRIPTION
since views are defautly white/black.. there is no way to make customNavigationTitleView and customNavigationBarView transparent. If we make the views clear, this allows for react-native screen to style its parent component to any opacity in javascript.