### PR TITLE
custom nav header updates

### DIFF
--- a/lib/ios/RNNRootViewController.m
+++ b/lib/ios/RNNRootViewController.m
@@ -102,15 +102,15 @@
 }
 
 - (void)setCustomNavigationComponentBackground {
+    if ([[self.navigationController.navigationBar.subviews objectAtIndex:1] isKindOfClass:[RNNCustomTitleView class]]) {
+        [[self.navigationController.navigationBar.subviews objectAtIndex:1] removeFromSuperview];
+    }
+    
 	if (self.options.topBar.background.component) {
-		RCTRootView *reactView = (RCTRootView*)[_creator createRootView:self.options.topBar.background.component rootViewId:@"navBarBackground"];
+        RCTRootView *reactView = (RCTRootView*)[_creator createRootView:self.options.topBar.background.component rootViewId:@"navBarBackground"];
 
-		RNNCustomTitleView *titleView = [[RNNCustomTitleView alloc] initWithFrame:self.navigationController.navigationBar.bounds subView:reactView alignment:@"fill"];
-		[self.navigationController.navigationBar insertSubview:titleView atIndex:1];
-		self.navigationController.navigationBar.clipsToBounds = YES;
-	} else if ([[self.navigationController.navigationBar.subviews objectAtIndex:1] isKindOfClass:[RNNCustomTitleView class]]) {
-		[[self.navigationController.navigationBar.subviews objectAtIndex:1] removeFromSuperview];
-		self.navigationController.navigationBar.clipsToBounds = NO;
+        RNNCustomTitleView *titleView = [[RNNCustomTitleView alloc] initWithFrame:self.navigationController.navigationBar.bounds subView:reactView alignment:@"fill"];
+        [self.navigationController.navigationBar insertSubview:titleView atIndex:1];
 	}
 }
 
@@ -157,7 +157,7 @@
 
 - (void)navigationController:(UINavigationController *)navigationController didShowViewController:(UIViewController *)viewController animated:(BOOL)animated{
 	RNNRootViewController* vc =  (RNNRootViewController*)viewController;
-	if (![vc.options.backButtonTransition isEqualToString:@"custom"]){
+	if (![vc.options.backButtonTransition isEqualToString:@"custom"]) {
 		navigationController.delegate = nil;
 	}
 }

--- a/lib/ios/RNNTopBarOptions.h
+++ b/lib/ios/RNNTopBarOptions.h
@@ -25,6 +25,7 @@
 @property (nonatomic, strong) NSNumber* backButtonHidden;
 @property (nonatomic, strong) NSString* backButtonTitle;
 @property (nonatomic, strong) NSNumber* hideBackButtonTitle;
+@property (nonatomic, strong) NSString* barStyle;
 
 @property (nonatomic, strong) NSString* componentName;
 

--- a/lib/ios/RNNTopBarOptions.m
+++ b/lib/ios/RNNTopBarOptions.m
@@ -167,7 +167,18 @@ extern const NSInteger BLUR_TOPBAR_TAG;
 	}
 	
 	viewController.navigationItem.hidesBackButton = [self.backButtonHidden boolValue];
-	
+    
+    if (self.barStyle) {
+        if ([self.barStyle isEqualToString:@"black"]) {
+            viewController.navigationController.navigationBar.barStyle = UIBarStyleBlack;
+        } else if ([self.barStyle isEqualToString:@"blackOpaque"]) {
+            viewController.navigationController.navigationBar.barStyle = UIBarStyleBlackOpaque;
+        } else if ([self.barStyle isEqualToString:@"blackTranslucent"]) {
+            viewController.navigationController.navigationBar.barStyle = UIBarStyleBlackTranslucent;
+        } else {
+            viewController.navigationController.navigationBar.barStyle = UIBarMetricsDefault;
+        }
+    }
 }
 
 -(void)storeOriginalTopBarImages:(UIViewController*)viewController {

--- a/lib/ios/RNNTopBarOptions.m
+++ b/lib/ios/RNNTopBarOptions.m
@@ -171,10 +171,6 @@ extern const NSInteger BLUR_TOPBAR_TAG;
     if (self.barStyle) {
         if ([self.barStyle isEqualToString:@"black"]) {
             viewController.navigationController.navigationBar.barStyle = UIBarStyleBlack;
-        } else if ([self.barStyle isEqualToString:@"blackOpaque"]) {
-            viewController.navigationController.navigationBar.barStyle = UIBarStyleBlackOpaque;
-        } else if ([self.barStyle isEqualToString:@"blackTranslucent"]) {
-            viewController.navigationController.navigationBar.barStyle = UIBarStyleBlackTranslucent;
         } else {
             viewController.navigationController.navigationBar.barStyle = UIBarMetricsDefault;
         }


### PR DESCRIPTION
- Add barStyle to topBarOptions to allow `viewController.navigationController.navigationBar.barStyle` to be customized
- prevent multiple component backgrounds from spawning
- allow background to bleed through (we can clip it in javascript through `overflow: "hidden"` style)