### PR TITLE
BUG: ios - Fix custom top bar not being applied after a navigation push

### DIFF
--- a/lib/ios/RNNRootViewController.m
+++ b/lib/ios/RNNRootViewController.m
@@ -13,7 +13,6 @@
 @property (nonatomic, strong) NSString* componentName;
 @property (nonatomic) BOOL _statusBarHidden;
 @property (nonatomic) BOOL isExternalComponent;
-@property (nonatomic) BOOL _optionsApplied;
 @property (nonatomic, copy) void (^rotationBlock)(void);
 @end
 
@@ -33,7 +32,7 @@
 	self.animator = [[RNNAnimator alloc] initWithTransitionOptions:self.options.customTransition];
 	self.creator = creator;
 	self.isExternalComponent = isExternalComponent;
-	
+
 	if (!self.isExternalComponent) {
 		self.view = [creator createRootView:self.componentName rootViewId:self.componentId];
 	}
@@ -52,11 +51,8 @@
 
 -(void)viewWillAppear:(BOOL)animated{
 	[super viewWillAppear:animated];
-  
-	if (!self._optionsApplied) {
-		[self.options applyOn:self];
-	}
-	self._optionsApplied = true;
+
+    [self.options applyOn:self];
 }
 
 -(void)viewDidAppear:(BOOL)animated {
@@ -95,7 +91,7 @@
 	if (!_customTitleView) {
 		if (self.options.topBar.title.component.name) {
 			RCTRootView *reactView = (RCTRootView*)[_creator createRootViewFromComponentOptions:self.options.topBar.title.component];
-			
+
 			_customTitleView = [[RNNCustomTitleView alloc] initWithFrame:self.navigationController.navigationBar.bounds subView:reactView alignment:self.options.topBar.title.component.alignment];
 			reactView.backgroundColor = UIColor.clearColor;
 			_customTitleView.backgroundColor = UIColor.clearColor;
@@ -103,14 +99,16 @@
 		} if ([self.navigationItem.title isKindOfClass:[RNNCustomTitleView class]] && !_customTitleView) {
 			self.navigationItem.title = nil;
 		}
-	}
+    } else if (_customTitleView.superview == nil) {
+        self.navigationItem.titleView = _customTitleView;
+    }
 }
 
 - (void)setCustomNavigationBarView {
 	if (!_customTopBar) {
 		if (self.options.topBar.component.name) {
 			RCTRootView *reactView = (RCTRootView*)[_creator createRootViewFromComponentOptions:self.options.topBar.component];
-			
+
 			_customTopBar = [[RNNCustomTitleView alloc] initWithFrame:self.navigationController.navigationBar.bounds subView:reactView alignment:@"fill"];
 			reactView.backgroundColor = UIColor.clearColor;
 			_customTopBar.backgroundColor = UIColor.clearColor;
@@ -118,14 +116,16 @@
 		} else if ([[self.navigationController.navigationBar.subviews lastObject] isKindOfClass:[RNNCustomTitleView class]] && !_customTopBar) {
 			[[self.navigationController.navigationBar.subviews lastObject] removeFromSuperview];
 		}
-	}
+    } else if (_customTopBar.superview == nil) {
+        [self.navigationController.navigationBar addSubview:_customTopBar];
+    }
 }
 
 - (void)setCustomNavigationComponentBackground {
 	if (!_customTopBarBackground) {
 		if (self.options.topBar.background.component.name) {
 			RCTRootView *reactView = (RCTRootView*)[_creator createRootViewFromComponentOptions:self.options.topBar.background.component];
-			
+
 			_customTopBarBackground = [[RNNCustomTitleView alloc] initWithFrame:self.navigationController.navigationBar.bounds subView:reactView alignment:@"fill"];
 			[self.navigationController.navigationBar insertSubview:_customTopBarBackground atIndex:1];
 			self.navigationController.navigationBar.clipsToBounds = YES;
@@ -133,7 +133,10 @@
 			[[self.navigationController.navigationBar.subviews objectAtIndex:1] removeFromSuperview];
 			self.navigationController.navigationBar.clipsToBounds = NO;
 		}
-	}
+    } else if (_customTopBarBackground == nil) {
+        [self.navigationController.navigationBar insertSubview:_customTopBarBackground atIndex:1];
+        self.navigationController.navigationBar.clipsToBounds = YES;
+    }
 }
 
 -(BOOL)isCustomTransitioned {


### PR DESCRIPTION
Since a push will remove the nav bar subviews, we have to reapply them once the view will appear.